### PR TITLE
Added two functions to address #28

### DIFF
--- a/R/text_calc_tfidf_ngrams.R
+++ b/R/text_calc_tfidf_ngrams.R
@@ -5,9 +5,10 @@
 #'
 #' @param df A data frame with at least two free-text columns (i.e. questions).
 #' @param q_cols A vector containing the names of the free-text columns.
-#' @param ngrams_type A string. Should be "unigrams","bigrams" or "trigrams".
+#' @param ngram_type A string. Should be "unigrams","bigrams" or "trigrams".
 #' @param top_n_ngrams Integer. Number of top ngrams to return per question. Defaults to all.
-#' @param with_ties Should ties be kept together? The default, FALSE, may return less rows than you request.
+#' @param with_ties Should ties be kept together? The default, TRUE, may return more rows than you request.
+#' @param stop_words Stop words to be removed. Defaults to tidytext::stop_words$word
 #'
 #' @return A data frame with six columns: question name; n-gram (word, bigram or trigram); count;
 #'     term-frequency; inverse document frequency; and TF-IDF.
@@ -20,7 +21,8 @@ text_calc_tfidf_ngrams <- function(df,
                               q_cols,
                               ngram_type = c("unigrams", "bigrams", "trigrams"),
                               top_n_ngrams = NULL,
-                              with_ties = FALSE) {
+                              with_ties = TRUE,
+                              stop_words = tidytext::stop_words$word) {
 
   if(length(q_cols)==1){
     stop('q_cols needs to have at least two elements for tf-idf calculations')
@@ -54,7 +56,7 @@ text_calc_tfidf_ngrams <- function(df,
     dplyr::filter( # Do this because some stop words make it through the TF-IDF filtering that happens below.
       dplyr::across(
         dplyr::starts_with("word"),
-        ~ !. %in% tidytext::stop_words$word
+        ~ !. %in% stop_words
       )
     ) %>%
     tidyr::unite(

--- a/R/text_calc_tfidf_ngrams.R
+++ b/R/text_calc_tfidf_ngrams.R
@@ -1,0 +1,84 @@
+#' Calculate TF-IDFs for unigrams, bigrams or trigrams
+#'
+#' For two or more free-text columns, return the unigrams, bigrams or trigrams with the
+#' largest TF-IDFs for the given columns.
+#'
+#' @param df A data frame with at least two free-text columns (i.e. questions).
+#' @param q_cols A vector containing the names of the free-text columns.
+#' @param ngrams_type A string. Should be "unigrams","bigrams" or "trigrams".
+#' @param top_n_ngrams Integer. Number of top ngrams to return per question. Defaults to all.
+#' @param with_ties Should ties be kept together? The default, FALSE, may return less rows than you request.
+#'
+#' @return A data frame with six columns: question name; n-gram (word, bigram or trigram); count;
+#'     term-frequency; inverse document frequency; and TF-IDF.
+#' @export
+#'
+#' @examples  df <- data.frame(q1 = c("hello", "good morning"), q2 = c("bye", "good night"))
+#' text_calc_tfidf_ngrams(df, c("q1", "q2"), "unigrams")
+
+text_calc_tfidf_ngrams <- function(df,
+                              q_cols,
+                              ngram_type = c("unigrams", "bigrams", "trigrams"),
+                              top_n_ngrams = NULL,
+                              with_ties = FALSE) {
+
+  if(length(q_cols)==1){
+    stop('q_cols needs to have at least two elements for tf-idf calculations')
+  }
+
+  # derive numeric type of ngram based on inputted string
+  ngrams_n <- ifelse(ngram_type == 'unigrams', 1,
+                     ifelse(ngram_type == 'bigrams', 2,
+                            ifelse(ngram_type == 'trigrams', 3,
+                                   stop("ngram_type must be 'unigrams', 'bigrams' or 'trigrams'"))))
+
+  # pivot input dataframe, so there are two columns: question name and response text
+  df_long <- tidyr::pivot_longer(df[,q_cols],
+                            cols = q_cols,
+                            names_to = "question_col",
+                            values_to = "text_col")
+
+
+  tfidf_ngrams <- df_long %>%
+    tidytext::unnest_tokens(
+      output = "ngram",
+      input = "text_col",
+      token = "ngrams",
+      n = ngrams_n
+    ) %>%
+    tidyr::separate(
+      ngram,
+      paste0("word", 1:ngrams_n),
+      sep = " "
+    ) %>%
+    dplyr::filter( # Do this because some stop words make it through the TF-IDF filtering that happens below.
+      dplyr::across(
+        dplyr::starts_with("word"),
+        ~ !. %in% tidytext::stop_words$word
+      )
+    ) %>%
+    tidyr::unite(
+      col = "ngram", paste0("word", 1:ngrams_n),
+      sep = " "
+    ) %>%
+    dplyr::count(
+      question_col,
+      ngram,
+      sort = TRUE
+    ) %>%
+    tidytext::bind_tf_idf(
+      ngram,
+      question_col,
+      n
+    )
+
+  # if top_n_ngrams is provided, only keep top n ngrams for each question
+  if(!is.null(top_n_ngrams)){
+    tfidf_ngrams <- tfidf_ngrams %>%
+      dplyr::group_by(question_col) %>%
+      dplyr::slice_max(tf_idf, n = top_n_ngrams, with_ties = with_ties) %>%
+      dplyr::ungroup()
+  }
+
+  return(tfidf_ngrams)
+}

--- a/R/text_get_top_ngrams.R
+++ b/R/text_get_top_ngrams.R
@@ -1,12 +1,12 @@
 #' Extract most common bigrams or trigrams
 #'
-#' For a vector of free-text consultation responses, return the most commonly used bigrams or trigrams.
+#' For a free-text column, return the most commonly used bigrams or trigrams.
 #'
 #' @param df A data frame with one free-text column.
 #' #' If your text is spread across several columns, you can merge them like this:
 #' df <- data.frame(text_col = unlist(df %>% select(question_cols))) %>% filter(!is.na(text_col))
 #' @param text_col_name A string containing the name of the free-text column.
-#' @param ngrams_type A string. Should be "bigrams" or "trigrams".
+#' @param ngram_type A string. Should be "bigrams" or "trigrams".
 #' @param min_freq Integer. Number of minimum count required for a ngram to be included in output. Defaults to 1.
 #'
 #' @return A data frame with two columns: n-gram (bigram or trigram); count.

--- a/R/text_get_top_ngrams.R
+++ b/R/text_get_top_ngrams.R
@@ -1,0 +1,49 @@
+#' Extract most common bigrams or trigrams
+#'
+#' For a vector of free-text consultation responses, return the most commonly used bigrams or trigrams.
+#'
+#' @param df A data frame with one free-text column.
+#' #' If your text is spread across several columns, you can merge them like this:
+#' df <- data.frame(text_col = unlist(df %>% select(question_cols))) %>% filter(!is.na(text_col))
+#' @param text_col_name A string containing the name of the free-text column.
+#' @param ngrams_type A string. Should be "bigrams" or "trigrams".
+#' @param min_freq Integer. Number of minimum count required for a ngram to be included in output. Defaults to 1.
+#'
+#' @return A data frame with two columns: n-gram (bigram or trigram); count.
+#' @export
+#'
+#' @examples library(janeaustenr)
+#' d <- tibble(txt = janeaustenr::prideprejudice)
+#' text_get_top_ngrams(d, "txt", ngram_type = 'bigram', min_freq = 10)
+
+text_get_top_ngrams <- function(df, text_col_name, ngram_type = c('bigram', 'trigram'), min_freq = 1){
+
+  ngrams_n <- ifelse(ngram_type == 'bigram', 2,
+                     ifelse(ngram_type == 'trigram', 3,
+                            stop("ngram_type must be 'bigram' or 'trigram'")))
+
+  ngrams <- df %>%
+    tidytext::unnest_tokens(output = ngram,
+                            input = !! rlang::sym(text_col_name),
+                            token = "ngrams",
+                            n = ngrams_n) %>%
+    tidyr::separate(ngram,
+                    paste0("word", 1:ngrams_n),
+                    sep = " ") %>%
+    dplyr::filter( # filter out stop words
+      dplyr::across(
+        dplyr::starts_with("word"),
+        ~ !. %in% tidytext::stop_words$word
+      )
+    ) %>%
+    tidyr::unite(
+      col = "ngram",
+      paste0("word", 1:ngrams_n),
+      sep = " "
+    ) %>%
+    dplyr::count(ngram, sort = TRUE) %>%
+    dplyr::filter(n>= min_freq)
+
+  return(ngrams)
+
+}


### PR DESCRIPTION
Added two functions to address #28 
text_get_top_ngrams:  For a free-text column, returns the most commonly used bigrams or trigrams.
text_calc_tfidf_ngrams: For two or more free-text columns, returns the unigrams, bigrams or trigrams with the largest TF-IDFs for the given columns.

This is to help identify terms for the multi-word glossary.
Thank you @ChrisBeeley. The function text_calc_tfidf_ngrams was inspired by your calc_tfidf_ngrams function (https://github.com/CDU-data-science-team/experienceAnalysis/blob/main/R/calc_tfidf_ngrams.R).